### PR TITLE
CHORE - Manage Minipay countries separately.

### DIFF
--- a/src/components/Widget/Widget.tsx
+++ b/src/components/Widget/Widget.tsx
@@ -29,6 +29,9 @@ export const Widget = () => {
       await switchChain({ chainId: 42220 });
     }
   };
+  
+  // we are carefully opening countries on the minipay opera wallet.
+  const miniPayCountries = ["US", "MX", "NG", "GH", "KE", "ZA"];
 
   const config = {
     buildUrl: true,
@@ -42,6 +45,8 @@ export const Widget = () => {
       default: i18n.language,
       supported: ["en", "es"],
     },
+    //undefined means every country
+    allowedCountries: isMiniPay ? miniPayCountries : undefined,
     theme: {
       container: {
         borderRadius: "10px",

--- a/src/components/Widget/Widget.tsx
+++ b/src/components/Widget/Widget.tsx
@@ -45,7 +45,8 @@ export const Widget = () => {
       default: i18n.language,
       supported: ["en", "es"],
     },
-    //undefined means every country
+    // If `isMiniPay` is true, restrict access to specific countries listed in `miniPayCountries`.
+    // If `isMiniPay` is false, setting `allowedCountries` to `undefined` allows access from all countries.
     allowedCountries: isMiniPay ? miniPayCountries : undefined,
     theme: {
       container: {


### PR DESCRIPTION
Use minipay detection to allow specific countries on the widget.