### PR TITLE
Update widget to 0.1.60

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@bandohq/widget": "^0.1.54",
+    "@bandohq/widget": "^0.1.60",
     "@bigmi/react": "^0.1.1",
     "@farcaster/frame-sdk": "^0.0.39",
     "@farcaster/frame-wagmi-connector": "^0.0.27",


### PR DESCRIPTION
This version includes brand ordering:

<img width="1275" height="812" alt="image" src="https://github.com/user-attachments/assets/c6a5a70f-4457-489c-b914-fcd97624b47e" />
